### PR TITLE
Making location info optional improves performance.

### DIFF
--- a/src/main/java/net/logstash/log4j/JSONEventLayout.java
+++ b/src/main/java/net/logstash/log4j/JSONEventLayout.java
@@ -15,6 +15,8 @@ import org.apache.log4j.spi.LocationInfo;
 
 public class JSONEventLayout extends Layout {
 
+    private boolean locationInfo = false;
+
     private String tags;
     private boolean ignoreThrowable = false;
 
@@ -45,10 +47,26 @@ public class JSONEventLayout extends Layout {
 	return formatted.substring(0,26) + ":" + formatted.substring(26);
     }
 
+    /**
+     * For backwards compatability, the default is to generate location information
+     * in the log messages.
+     */
+    public JSONEventLayout() {
+        this(true);
+    }
+
+    /**
+     * Creates a layout that optionally inserts location information into log messages.
+     *
+     * @param locationInfo whether or not to include location information in the log messages.
+     */
+    public JSONEventLayout(boolean locationInfo) {
+        this.locationInfo = locationInfo;
+    }
+
     public String format(LoggingEvent loggingEvent) {
         hostname = new HostData().getHostName();
         timestamp = loggingEvent.getTimeStamp();
-        info = loggingEvent.getLocationInformation();
         fieldData = new HashMap<String, Object>();
         exceptionInformation = new HashMap<String, Object>();
         mdc = loggingEvent.getProperties();
@@ -75,8 +93,7 @@ public class JSONEventLayout extends Layout {
             addFieldData("exception",exceptionInformation);
         }
 
-
-        if(loggingEvent.locationInformationExists()) {
+        if(locationInfo) {
             info = loggingEvent.getLocationInformation();
             addFieldData("file",info.getFileName());
             addFieldData("line_number",info.getLineNumber());
@@ -94,6 +111,24 @@ public class JSONEventLayout extends Layout {
 
     public boolean ignoresThrowable() {
         return ignoreThrowable;
+    }
+
+    /**
+     * Query whether log messages include location information.
+     *
+     * @return true if location information is included in log messages, false otherwise.
+     */
+    public boolean getLocationInfo(){
+        return locationInfo;
+    }
+
+    /**
+     * Set whether log messages should include location information.
+     *
+     * @param locationInfo true if location information should be included, false otherwise.
+     */
+    public void setLocationInfo(boolean locationInfo){
+        this.locationInfo = locationInfo;
     }
 
     public void activateOptions() {

--- a/src/main/resources/log4j.locinfo.properties.example
+++ b/src/main/resources/log4j.locinfo.properties.example
@@ -1,0 +1,6 @@
+log4j.rootLogger=TRACE, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Threshold=TRACE
+log4j.appender.stdout.layout=net.logstash.log4j.JSONEventLayout
+log4j.appender.stdout.layout.locationInfo=true

--- a/src/test/java/net/logstash/log4j/JSONEventLayoutTest.java
+++ b/src/test/java/net/logstash/log4j/JSONEventLayoutTest.java
@@ -152,6 +152,8 @@ public class JSONEventLayoutTest {
         layout.setLocationInfo(prevLocationInfo);
     }
 
+    @Test
+    @Ignore
     public void measureJSONEventLayoutLocationInfoPerformance() {
         JSONEventLayout layout = (JSONEventLayout)appender.getLayout();
         boolean locationInfo = layout.getLocationInfo();

--- a/src/test/java/net/logstash/log4j/JSONEventLayoutTest.java
+++ b/src/test/java/net/logstash/log4j/JSONEventLayoutTest.java
@@ -1,14 +1,12 @@
 package net.logstash.log4j;
 
+import java.io.OutputStreamWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 
-import org.apache.log4j.Logger;
-import org.apache.log4j.Level;
-import org.apache.log4j.NDC;
-import org.apache.log4j.MDC;
+import org.apache.log4j.*;
 
 import junit.framework.Assert;
 import org.junit.After;
@@ -130,6 +128,56 @@ public class JSONEventLayoutTest {
         JSONObject atFields = (JSONObject) jsonObject.get("@fields");
 
         Assert.assertNotNull("File value is missing", atFields.get("file"));
+    }
+
+    @Test
+    public void testJSONEventLayoutNoLocationInfo() {
+        JSONEventLayout layout = (JSONEventLayout)appender.getLayout();
+        boolean prevLocationInfo = layout.getLocationInfo();
+
+        layout.setLocationInfo(false);
+
+        logger.warn("warning dawg");
+        String message = appender.getMessages()[0];
+        Object obj = JSONValue.parse(message);
+        JSONObject jsonObject = (JSONObject) obj;
+        JSONObject atFields = (JSONObject) jsonObject.get("@fields");
+
+        Assert.assertFalse("atFields contains file value", atFields.containsKey("file"));
+        Assert.assertFalse("atFields contains line_number value", atFields.containsKey("line_number"));
+        Assert.assertFalse("atFields contains class value", atFields.containsKey("class"));
+        Assert.assertFalse("atFields contains method value", atFields.containsKey("method"));
+
+        // Revert the change to the layout to leave it as we found it.
+        layout.setLocationInfo(prevLocationInfo);
+    }
+
+    public void measureJSONEventLayoutLocationInfoPerformance() {
+        JSONEventLayout layout = (JSONEventLayout)appender.getLayout();
+        boolean locationInfo = layout.getLocationInfo();
+        int iterations = 100000;
+        long start, stop;
+
+        start = System.currentTimeMillis();
+        for (int i=0; i<iterations; i++){
+            logger.warn("warning dawg");
+        }
+        stop = System.currentTimeMillis();
+        long firstMeasurement = stop - start;
+
+        layout.setLocationInfo(!locationInfo);
+        start = System.currentTimeMillis();
+        for (int i=0; i<iterations; i++){
+            logger.warn("warning dawg");
+        }
+        stop = System.currentTimeMillis();
+        long secondMeasurement = stop - start;
+
+        System.out.println("First Measurement (locationInfo: " + locationInfo +"): " + firstMeasurement);
+        System.out.println("Second Measurement (locationInfo: " + !locationInfo +"): " + secondMeasurement);
+
+        // Clean up
+        layout.setLocationInfo(!locationInfo);
     }
 
 }


### PR DESCRIPTION
Hi.

I have made the location information in the log messages optional after finding a bug in Grails which rendered them completely useless (the location was always inside a SLF4J class - see: http://jira.grails.org/browse/GRAILS-9826). Until I get that fixed I wanted to turn off the generation of location information and found out that this couldn't be done with the current version of your layout.

I've added a constructor, getter and setter for whether location information should be included in the log message. If not, the location information is not generated at all which saves quite some time.

I also added unit tests for this and to measure the performance difference between having the location information or not. The performance difference is quite significant. The following is the result of a typical run where I output 100.000 warn messages:
    First Measurement (locationInfo: true): 4553
    Second Measurement (locationInfo: false): 729

The measurement method is marked as a @Test for convenience but I also put a @Ignore on it for now. This does generate a warning message so it could be done better but unfortunately I don't have time to figure out what the right way to do this is now but I wanted to include this method so you could see that there is in fact a benefit of being able to exclude this information.
