### PR TITLE
Optimize : request hostname to system only once and use ThreadLocal for SimpleDateFormat

### DIFF
--- a/src/main/java/net/logstash/log4j/JSONEventLayout.java
+++ b/src/main/java/net/logstash/log4j/JSONEventLayout.java
@@ -30,16 +30,20 @@ public class JSONEventLayout extends Layout {
     private HashMap<String, Object> exceptionInformation;
 
     private JSONObject logstashEvent;
+    private static final ThreadLocal<SimpleDateFormat> THREAD_LOCAL_SDF = new ThreadLocal<SimpleDateFormat>() {
+        @Override
+        protected SimpleDateFormat initialValue() {
+            return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+        }
+    };
 
     public static String dateFormat(long timestamp) {
 	Date date = new Date(timestamp);
 	/*
-	 * SimpleDateFormat isn't thread safe so I need one 
-	 * instance per call, otherwise I'd have to pull in
-	 * joda time.
+	 * SimpleDateFormat isn't thread safe so we use a ThreadLocal,
+	 *  otherwise we'd have to pull in joda time.
 	 */
-	SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
-	String formatted = format.format(date);
+	String formatted = THREAD_LOCAL_SDF.get().format(date);
 
 	/* 
 	 * No native support for ISO8601 woo!

--- a/src/main/java/net/logstash/log4j/JSONEventLayout.java
+++ b/src/main/java/net/logstash/log4j/JSONEventLayout.java
@@ -1,17 +1,17 @@
 package net.logstash.log4j;
 
 import net.logstash.log4j.data.HostData;
-
-import java.util.*;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-
 import net.minidev.json.JSONObject;
-import org.apache.commons.lang.*;
+import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Layout;
+import org.apache.log4j.spi.LocationInfo;
 import org.apache.log4j.spi.LoggingEvent;
 import org.apache.log4j.spi.ThrowableInformation;
-import org.apache.log4j.spi.LocationInfo;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 public class JSONEventLayout extends Layout {
 
@@ -21,7 +21,7 @@ public class JSONEventLayout extends Layout {
     private boolean ignoreThrowable = false;
 
     private boolean activeIgnoreThrowable = ignoreThrowable;
-    private String hostname = new HostData().getHostName();;
+    private String hostname = new HostData().getHostName();
     private long timestamp;
     private String ndc;
     private Map mdc;
@@ -38,17 +38,17 @@ public class JSONEventLayout extends Layout {
     };
 
     public static String dateFormat(long timestamp) {
-	Date date = new Date(timestamp);
-	/*
+        Date date = new Date(timestamp);
+    /*
 	 * SimpleDateFormat isn't thread safe so we use a ThreadLocal,
 	 *  otherwise we'd have to pull in joda time.
 	 */
-	String formatted = THREAD_LOCAL_SDF.get().format(date);
+        String formatted = THREAD_LOCAL_SDF.get().format(date);
 
 	/* 
 	 * No native support for ISO8601 woo!
 	 */
-	return formatted.substring(0,26) + ":" + formatted.substring(26);
+        return formatted.substring(0, 26) + ":" + formatted.substring(26);
     }
 
     /**
@@ -77,38 +77,38 @@ public class JSONEventLayout extends Layout {
 
         logstashEvent = new JSONObject();
 
-        logstashEvent.put("@source_host",hostname);
-        logstashEvent.put("@message",loggingEvent.getRenderedMessage());
-        logstashEvent.put("@timestamp",dateFormat(timestamp));
+        logstashEvent.put("@source_host", hostname);
+        logstashEvent.put("@message", loggingEvent.getRenderedMessage());
+        logstashEvent.put("@timestamp", dateFormat(timestamp));
 
-        if(loggingEvent.getThrowableInformation() != null) {
+        if (loggingEvent.getThrowableInformation() != null) {
             final ThrowableInformation throwableInformation = loggingEvent.getThrowableInformation();
-            if(throwableInformation.getThrowable().getClass().getCanonicalName() != null){
-                exceptionInformation.put("exception_class",throwableInformation.getThrowable().getClass().getCanonicalName());
+            if (throwableInformation.getThrowable().getClass().getCanonicalName() != null) {
+                exceptionInformation.put("exception_class", throwableInformation.getThrowable().getClass().getCanonicalName());
             }
-            if(throwableInformation.getThrowable().getMessage() != null) {
-                exceptionInformation.put("exception_message",throwableInformation.getThrowable().getMessage());
+            if (throwableInformation.getThrowable().getMessage() != null) {
+                exceptionInformation.put("exception_message", throwableInformation.getThrowable().getMessage());
             }
-            if( throwableInformation.getThrowableStrRep() != null) {
-                String stackTrace = StringUtils.join(throwableInformation.getThrowableStrRep(),"\n");
-                exceptionInformation.put("stacktrace",stackTrace);
+            if (throwableInformation.getThrowableStrRep() != null) {
+                String stackTrace = StringUtils.join(throwableInformation.getThrowableStrRep(), "\n");
+                exceptionInformation.put("stacktrace", stackTrace);
             }
-            addFieldData("exception",exceptionInformation);
+            addFieldData("exception", exceptionInformation);
         }
 
-        if(locationInfo) {
+        if (locationInfo) {
             info = loggingEvent.getLocationInformation();
-            addFieldData("file",info.getFileName());
-            addFieldData("line_number",info.getLineNumber());
-            addFieldData("class",info.getClassName());
-            addFieldData("method",info.getMethodName());
+            addFieldData("file", info.getFileName());
+            addFieldData("line_number", info.getLineNumber());
+            addFieldData("class", info.getClassName());
+            addFieldData("method", info.getMethodName());
         }
 
-        addFieldData("mdc",mdc);
-        addFieldData("ndc",ndc);
-        addFieldData("level",loggingEvent.getLevel().toString());
+        addFieldData("mdc", mdc);
+        addFieldData("ndc", ndc);
+        addFieldData("level", loggingEvent.getLevel().toString());
 
-        logstashEvent.put("@fields",fieldData);
+        logstashEvent.put("@fields", fieldData);
         return logstashEvent.toString() + "\n";
     }
 
@@ -121,7 +121,7 @@ public class JSONEventLayout extends Layout {
      *
      * @return true if location information is included in log messages, false otherwise.
      */
-    public boolean getLocationInfo(){
+    public boolean getLocationInfo() {
         return locationInfo;
     }
 
@@ -130,7 +130,7 @@ public class JSONEventLayout extends Layout {
      *
      * @param locationInfo true if location information should be included, false otherwise.
      */
-    public void setLocationInfo(boolean locationInfo){
+    public void setLocationInfo(boolean locationInfo) {
         this.locationInfo = locationInfo;
     }
 
@@ -138,8 +138,8 @@ public class JSONEventLayout extends Layout {
         activeIgnoreThrowable = ignoreThrowable;
     }
 
-    private void addFieldData(String keyname, Object keyval){
-        if(null != keyval){
+    private void addFieldData(String keyname, Object keyval) {
+        if (null != keyval) {
             fieldData.put(keyname, keyval);
         }
     }

--- a/src/main/java/net/logstash/log4j/JSONEventLayout.java
+++ b/src/main/java/net/logstash/log4j/JSONEventLayout.java
@@ -21,7 +21,7 @@ public class JSONEventLayout extends Layout {
     private boolean ignoreThrowable = false;
 
     private boolean activeIgnoreThrowable = ignoreThrowable;
-    private String hostname;
+    private String hostname = new HostData().getHostName();;
     private long timestamp;
     private String ndc;
     private Map mdc;
@@ -65,7 +65,6 @@ public class JSONEventLayout extends Layout {
     }
 
     public String format(LoggingEvent loggingEvent) {
-        hostname = new HostData().getHostName();
         timestamp = loggingEvent.getTimeStamp();
         fieldData = new HashMap<String, Object>();
         exceptionInformation = new HashMap<String, Object>();

--- a/src/main/java/net/logstash/log4j/data/HostData.java
+++ b/src/main/java/net/logstash/log4j/data/HostData.java
@@ -6,16 +6,18 @@ public class HostData {
 
     public String hostName;
 
-    public String getHostName(){
+    public String getHostName() {
         return hostName;
     }
+
     public void setHostName(String hostName) {
         this.hostName = hostName;
     }
+
     public HostData() {
         try {
             this.hostName = java.net.InetAddress.getLocalHost().getHostName();
-        }catch (UnknownHostException e) {
+        } catch (UnknownHostException e) {
             setHostName("unknown-host");
         }
     }


### PR DESCRIPTION
- request hostname only once, when the JSONEventLayout class is initialized
- use a _ThreadLocal<SimpleDateFormat>_ instead of creating a new _SimpleDateFormat_ for each call to the _format_ static method
- bonus: organized imports (intellij idea style) + format code

I saw a performance increase of 30% on the _measureJSONEventLayoutLocationInfoPerformance_ test method on my system.
