### PR TITLE
Optimize : request hostname to system only once and use DateFormatUtils for date formating

### DIFF
--- a/src/main/java/net/logstash/log4j/JSONEventLayout.java
+++ b/src/main/java/net/logstash/log4j/JSONEventLayout.java
@@ -8,6 +8,7 @@ import java.text.SimpleDateFormat;
 
 import net.minidev.json.JSONObject;
 import org.apache.commons.lang.*;
+import org.apache.commons.lang.time.DateFormatUtils;
 import org.apache.log4j.Layout;
 import org.apache.log4j.spi.LoggingEvent;
 import org.apache.log4j.spi.ThrowableInformation;
@@ -21,7 +22,7 @@ public class JSONEventLayout extends Layout {
     private boolean ignoreThrowable = false;
 
     private boolean activeIgnoreThrowable = ignoreThrowable;
-    private String hostname = new HostData().getHostName();;
+    private String hostname = new HostData().getHostName();
     private long timestamp;
     private String ndc;
     private Map mdc;
@@ -32,19 +33,7 @@ public class JSONEventLayout extends Layout {
     private JSONObject logstashEvent;
 
     public static String dateFormat(long timestamp) {
-	Date date = new Date(timestamp);
-	/*
-	 * SimpleDateFormat isn't thread safe so I need one 
-	 * instance per call, otherwise I'd have to pull in
-	 * joda time.
-	 */
-	SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
-	String formatted = format.format(date);
-
-	/* 
-	 * No native support for ISO8601 woo!
-	 */
-	return formatted.substring(0,26) + ":" + formatted.substring(26);
+	return DateFormatUtils.ISO_DATETIME_TIME_ZONE_FORMAT.format(new Date(timestamp));
     }
 
     /**

--- a/src/main/java/net/logstash/log4j/JSONEventLayout.java
+++ b/src/main/java/net/logstash/log4j/JSONEventLayout.java
@@ -3,7 +3,7 @@ package net.logstash.log4j;
 import net.logstash.log4j.data.HostData;
 import net.minidev.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.time.DateFormatUtils;
+import org.apache.commons.lang.time.FastDateFormat;
 import org.apache.log4j.Layout;
 import org.apache.log4j.spi.LocationInfo;
 import org.apache.log4j.spi.LoggingEvent;
@@ -30,9 +30,10 @@ public class JSONEventLayout extends Layout {
     private HashMap<String, Object> exceptionInformation;
 
     private JSONObject logstashEvent;
+    public static final FastDateFormat ISO_DATETIME_TIME_ZONE_FORMAT_WITH_MILLIS = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss.SSSZZ");
 
     public static String dateFormat(long timestamp) {
-        return DateFormatUtils.ISO_DATETIME_TIME_ZONE_FORMAT.format(new Date(timestamp));
+        return ISO_DATETIME_TIME_ZONE_FORMAT_WITH_MILLIS.format(new Date(timestamp));
     }
 
     /**

--- a/src/main/java/net/logstash/log4j/JSONEventLayout.java
+++ b/src/main/java/net/logstash/log4j/JSONEventLayout.java
@@ -21,7 +21,7 @@ public class JSONEventLayout extends Layout {
     private boolean ignoreThrowable = false;
 
     private boolean activeIgnoreThrowable = ignoreThrowable;
-    private String hostname;
+    private String hostname = new HostData().getHostName();;
     private long timestamp;
     private String ndc;
     private Map mdc;
@@ -65,7 +65,6 @@ public class JSONEventLayout extends Layout {
     }
 
     public String format(LoggingEvent loggingEvent) {
-        hostname = new HostData().getHostName();
         timestamp = loggingEvent.getTimeStamp();
         fieldData = new HashMap<String, Object>();
         exceptionInformation = new HashMap<String, Object>();

--- a/src/main/java/net/logstash/log4j/JSONEventLayout.java
+++ b/src/main/java/net/logstash/log4j/JSONEventLayout.java
@@ -37,7 +37,7 @@ public class JSONEventLayout extends Layout {
     }
 
     /**
-     * For backwards compatability, the default is to generate location information
+     * For backwards compatibility, the default is to generate location information
      * in the log messages.
      */
     public JSONEventLayout() {

--- a/src/main/java/net/logstash/log4j/JSONEventLayout.java
+++ b/src/main/java/net/logstash/log4j/JSONEventLayout.java
@@ -1,18 +1,17 @@
 package net.logstash.log4j;
 
 import net.logstash.log4j.data.HostData;
-
-import java.util.*;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-
 import net.minidev.json.JSONObject;
-import org.apache.commons.lang.*;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.time.DateFormatUtils;
 import org.apache.log4j.Layout;
+import org.apache.log4j.spi.LocationInfo;
 import org.apache.log4j.spi.LoggingEvent;
 import org.apache.log4j.spi.ThrowableInformation;
-import org.apache.log4j.spi.LocationInfo;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 public class JSONEventLayout extends Layout {
 
@@ -33,7 +32,7 @@ public class JSONEventLayout extends Layout {
     private JSONObject logstashEvent;
 
     public static String dateFormat(long timestamp) {
-	return DateFormatUtils.ISO_DATETIME_TIME_ZONE_FORMAT.format(new Date(timestamp));
+        return DateFormatUtils.ISO_DATETIME_TIME_ZONE_FORMAT.format(new Date(timestamp));
     }
 
     /**
@@ -62,38 +61,38 @@ public class JSONEventLayout extends Layout {
 
         logstashEvent = new JSONObject();
 
-        logstashEvent.put("@source_host",hostname);
-        logstashEvent.put("@message",loggingEvent.getRenderedMessage());
-        logstashEvent.put("@timestamp",dateFormat(timestamp));
+        logstashEvent.put("@source_host", hostname);
+        logstashEvent.put("@message", loggingEvent.getRenderedMessage());
+        logstashEvent.put("@timestamp", dateFormat(timestamp));
 
-        if(loggingEvent.getThrowableInformation() != null) {
+        if (loggingEvent.getThrowableInformation() != null) {
             final ThrowableInformation throwableInformation = loggingEvent.getThrowableInformation();
-            if(throwableInformation.getThrowable().getClass().getCanonicalName() != null){
-                exceptionInformation.put("exception_class",throwableInformation.getThrowable().getClass().getCanonicalName());
+            if (throwableInformation.getThrowable().getClass().getCanonicalName() != null) {
+                exceptionInformation.put("exception_class", throwableInformation.getThrowable().getClass().getCanonicalName());
             }
-            if(throwableInformation.getThrowable().getMessage() != null) {
-                exceptionInformation.put("exception_message",throwableInformation.getThrowable().getMessage());
+            if (throwableInformation.getThrowable().getMessage() != null) {
+                exceptionInformation.put("exception_message", throwableInformation.getThrowable().getMessage());
             }
-            if( throwableInformation.getThrowableStrRep() != null) {
-                String stackTrace = StringUtils.join(throwableInformation.getThrowableStrRep(),"\n");
-                exceptionInformation.put("stacktrace",stackTrace);
+            if (throwableInformation.getThrowableStrRep() != null) {
+                String stackTrace = StringUtils.join(throwableInformation.getThrowableStrRep(), "\n");
+                exceptionInformation.put("stacktrace", stackTrace);
             }
-            addFieldData("exception",exceptionInformation);
+            addFieldData("exception", exceptionInformation);
         }
 
-        if(locationInfo) {
+        if (locationInfo) {
             info = loggingEvent.getLocationInformation();
-            addFieldData("file",info.getFileName());
-            addFieldData("line_number",info.getLineNumber());
-            addFieldData("class",info.getClassName());
-            addFieldData("method",info.getMethodName());
+            addFieldData("file", info.getFileName());
+            addFieldData("line_number", info.getLineNumber());
+            addFieldData("class", info.getClassName());
+            addFieldData("method", info.getMethodName());
         }
 
-        addFieldData("mdc",mdc);
-        addFieldData("ndc",ndc);
-        addFieldData("level",loggingEvent.getLevel().toString());
+        addFieldData("mdc", mdc);
+        addFieldData("ndc", ndc);
+        addFieldData("level", loggingEvent.getLevel().toString());
 
-        logstashEvent.put("@fields",fieldData);
+        logstashEvent.put("@fields", fieldData);
         return logstashEvent.toString() + "\n";
     }
 
@@ -106,7 +105,7 @@ public class JSONEventLayout extends Layout {
      *
      * @return true if location information is included in log messages, false otherwise.
      */
-    public boolean getLocationInfo(){
+    public boolean getLocationInfo() {
         return locationInfo;
     }
 
@@ -115,7 +114,7 @@ public class JSONEventLayout extends Layout {
      *
      * @param locationInfo true if location information should be included, false otherwise.
      */
-    public void setLocationInfo(boolean locationInfo){
+    public void setLocationInfo(boolean locationInfo) {
         this.locationInfo = locationInfo;
     }
 
@@ -123,8 +122,8 @@ public class JSONEventLayout extends Layout {
         activeIgnoreThrowable = ignoreThrowable;
     }
 
-    private void addFieldData(String keyname, Object keyval){
-        if(null != keyval){
+    private void addFieldData(String keyname, Object keyval) {
+        if (null != keyval) {
             fieldData.put(keyname, keyval);
         }
     }

--- a/src/main/java/net/logstash/log4j/data/HostData.java
+++ b/src/main/java/net/logstash/log4j/data/HostData.java
@@ -6,16 +6,18 @@ public class HostData {
 
     public String hostName;
 
-    public String getHostName(){
+    public String getHostName() {
         return hostName;
     }
+
     public void setHostName(String hostName) {
         this.hostName = hostName;
     }
+
     public HostData() {
         try {
             this.hostName = java.net.InetAddress.getLocalHost().getHostName();
-        }catch (UnknownHostException e) {
+        } catch (UnknownHostException e) {
             setHostName("unknown-host");
         }
     }

--- a/src/test/java/net/logstash/log4j/JSONEventLayoutTest.java
+++ b/src/test/java/net/logstash/log4j/JSONEventLayoutTest.java
@@ -1,21 +1,15 @@
 package net.logstash.log4j;
 
-import java.io.OutputStreamWriter;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-
-import org.apache.log4j.*;
-
 import junit.framework.Assert;
-import org.junit.After;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.Ignore;
-
 import net.minidev.json.JSONObject;
 import net.minidev.json.JSONValue;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.log4j.NDC;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
 
 /**
  * Created with IntelliJ IDEA.
@@ -27,7 +21,7 @@ import net.minidev.json.JSONValue;
 public class JSONEventLayoutTest {
     static Logger logger;
     static MockAppender appender;
-    static final String[] logstashFields = new String[] {
+    static final String[] logstashFields = new String[]{
             "@message",
             "@source_host",
             "@fields",
@@ -35,7 +29,7 @@ public class JSONEventLayoutTest {
     };
 
     @BeforeClass
-    public static void setupTestAppender(){
+    public static void setupTestAppender() {
         appender = new MockAppender(new JSONEventLayout());
         logger = Logger.getRootLogger();
         appender.setThreshold(Level.TRACE);
@@ -45,7 +39,7 @@ public class JSONEventLayoutTest {
     }
 
     @After
-    public void clearTestAppender(){
+    public void clearTestAppender() {
         NDC.clear();
         appender.clear();
         appender.close();
@@ -54,24 +48,24 @@ public class JSONEventLayoutTest {
     @Test
     public void testJSONEventLayoutIsJSON() {
         logger.info("this is an info message");
-        String  message = appender.getMessages()[0];
+        String message = appender.getMessages()[0];
         Assert.assertTrue("Event is not valid JSON", JSONValue.isValidJsonStrict(message));
     }
 
     @Test
-    public void testJSONEventLayoutHasKeys(){
+    public void testJSONEventLayoutHasKeys() {
         logger.info("this is a test message");
         String message = appender.getMessages()[0];
         Object obj = JSONValue.parse(message);
         JSONObject jsonObject = (JSONObject) obj;
 
-        for(String fieldName : logstashFields){
+        for (String fieldName : logstashFields) {
             Assert.assertTrue("Event does not contain field: " + fieldName, jsonObject.containsKey(fieldName));
         }
     }
 
     @Test
-    public void testJSONEventLayoutHasFieldLevel(){
+    public void testJSONEventLayoutHasFieldLevel() {
         logger.fatal("this is a new test message");
         String message = appender.getMessages()[0];
         Object obj = JSONValue.parse(message);
@@ -82,7 +76,7 @@ public class JSONEventLayoutTest {
     }
 
     @Test
-    public void testJSONEventLayoutHasNDC(){
+    public void testJSONEventLayoutHasNDC() {
         String ndcData = new String("json-layout-test");
         NDC.push(ndcData);
         logger.warn("I should have NDC data in my log");
@@ -95,17 +89,17 @@ public class JSONEventLayoutTest {
     }
 
     @Test
-    public void testJSONEventLayoutExceptions(){
+    public void testJSONEventLayoutExceptions() {
         String exceptionMessage = new String("shits on fire, yo");
-        logger.fatal("uh-oh",new IllegalArgumentException(exceptionMessage));
+        logger.fatal("uh-oh", new IllegalArgumentException(exceptionMessage));
         String message = appender.getMessages()[0];
         Object obj = JSONValue.parse(message);
         JSONObject jsonObject = (JSONObject) obj;
         JSONObject atFields = (JSONObject) jsonObject.get("@fields");
         JSONObject exceptionInformation = (JSONObject) atFields.get("exception");
 
-        Assert.assertEquals("Exception class missing","java.lang.IllegalArgumentException",exceptionInformation.get("exception_class"));
-        Assert.assertEquals("Exception exception message",exceptionMessage,exceptionInformation.get("exception_message"));
+        Assert.assertEquals("Exception class missing", "java.lang.IllegalArgumentException", exceptionInformation.get("exception_class"));
+        Assert.assertEquals("Exception exception message", exceptionMessage, exceptionInformation.get("exception_message"));
     }
 
     @Test
@@ -116,7 +110,7 @@ public class JSONEventLayoutTest {
         JSONObject jsonObject = (JSONObject) obj;
         JSONObject atFields = (JSONObject) jsonObject.get("@fields");
 
-        Assert.assertEquals("Logged class does not match",this.getClass().getCanonicalName().toString(),atFields.get("class"));
+        Assert.assertEquals("Logged class does not match", this.getClass().getCanonicalName().toString(), atFields.get("class"));
     }
 
     @Test
@@ -132,7 +126,7 @@ public class JSONEventLayoutTest {
 
     @Test
     public void testJSONEventLayoutNoLocationInfo() {
-        JSONEventLayout layout = (JSONEventLayout)appender.getLayout();
+        JSONEventLayout layout = (JSONEventLayout) appender.getLayout();
         boolean prevLocationInfo = layout.getLocationInfo();
 
         layout.setLocationInfo(false);
@@ -155,13 +149,13 @@ public class JSONEventLayoutTest {
     @Test
     @Ignore
     public void measureJSONEventLayoutLocationInfoPerformance() {
-        JSONEventLayout layout = (JSONEventLayout)appender.getLayout();
+        JSONEventLayout layout = (JSONEventLayout) appender.getLayout();
         boolean locationInfo = layout.getLocationInfo();
         int iterations = 100000;
         long start, stop;
 
         start = System.currentTimeMillis();
-        for (int i=0; i<iterations; i++){
+        for (int i = 0; i < iterations; i++) {
             logger.warn("warning dawg");
         }
         stop = System.currentTimeMillis();
@@ -169,17 +163,22 @@ public class JSONEventLayoutTest {
 
         layout.setLocationInfo(!locationInfo);
         start = System.currentTimeMillis();
-        for (int i=0; i<iterations; i++){
+        for (int i = 0; i < iterations; i++) {
             logger.warn("warning dawg");
         }
         stop = System.currentTimeMillis();
         long secondMeasurement = stop - start;
 
-        System.out.println("First Measurement (locationInfo: " + locationInfo +"): " + firstMeasurement);
-        System.out.println("Second Measurement (locationInfo: " + !locationInfo +"): " + secondMeasurement);
+        System.out.println("First Measurement (locationInfo: " + locationInfo + "): " + firstMeasurement);
+        System.out.println("Second Measurement (locationInfo: " + !locationInfo + "): " + secondMeasurement);
 
         // Clean up
         layout.setLocationInfo(!locationInfo);
     }
 
+    @Test
+    public void testDateFormat() {
+        long timestamp = 1364844991207L;
+        Assert.assertEquals("format does not produce expected output", "2013-04-01T21:36:31.207+02:00", JSONEventLayout.dateFormat(timestamp));
+    }
 }


### PR DESCRIPTION
- request hostname only once, when the JSONEventLayout class is initialized
- use commons-lang DateFormatUtils that is thread safe (and commons-lang is already a dependency). Moreover, this part of the code is now consistent with what was made in the _logstash-logback-encoder_
- bonus: organized imports (intellij idea style) + format code

+30% performance (average) compared to the "head", better performance too compared to the ThreadLocal version (https://github.com/logstash/log4j-jsonevent-layout/pull/9)
