### PR TITLE
force @timestamp to UTC

### DIFF
--- a/src/main/java/net/logstash/log4j/JSONEventLayout.java
+++ b/src/main/java/net/logstash/log4j/JSONEventLayout.java
@@ -37,7 +37,7 @@ public class JSONEventLayout extends Layout {
     public static final FastDateFormat ISO_DATETIME_TIME_ZONE_FORMAT_WITH_MILLIS = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", UTC);
 
     public static String dateFormat(long timestamp) {
-        return ISO_DATETIME_TIME_ZONE_FORMAT_WITH_MILLIS.format(new Date(timestamp));
+        return ISO_DATETIME_TIME_ZONE_FORMAT_WITH_MILLIS.format(timestamp);
     }
 
     /**

--- a/src/main/java/net/logstash/log4j/JSONEventLayout.java
+++ b/src/main/java/net/logstash/log4j/JSONEventLayout.java
@@ -12,6 +12,7 @@ import org.apache.log4j.spi.ThrowableInformation;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TimeZone;
 
 public class JSONEventLayout extends Layout {
 
@@ -31,7 +32,9 @@ public class JSONEventLayout extends Layout {
     private HashMap<String, Object> exceptionInformation;
 
     private JSONObject logstashEvent;
-    public static final FastDateFormat ISO_DATETIME_TIME_ZONE_FORMAT_WITH_MILLIS = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss.SSSZZ");
+
+    public static final TimeZone UTC = TimeZone.getTimeZone("UTC");
+    public static final FastDateFormat ISO_DATETIME_TIME_ZONE_FORMAT_WITH_MILLIS = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", UTC);
 
     public static String dateFormat(long timestamp) {
         return ISO_DATETIME_TIME_ZONE_FORMAT_WITH_MILLIS.format(new Date(timestamp));

--- a/src/main/java/net/logstash/log4j/JSONEventLayoutV1.java
+++ b/src/main/java/net/logstash/log4j/JSONEventLayoutV1.java
@@ -37,7 +37,7 @@ public class JSONEventLayoutV1 extends Layout {
     public static final FastDateFormat ISO_DATETIME_TIME_ZONE_FORMAT_WITH_MILLIS = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", UTC);
 
     public static String dateFormat(long timestamp) {
-        return ISO_DATETIME_TIME_ZONE_FORMAT_WITH_MILLIS.format(new Date(timestamp));
+        return ISO_DATETIME_TIME_ZONE_FORMAT_WITH_MILLIS.format(timestamp);
     }
 
     /**

--- a/src/main/java/net/logstash/log4j/JSONEventLayoutV1.java
+++ b/src/main/java/net/logstash/log4j/JSONEventLayoutV1.java
@@ -12,6 +12,7 @@ import org.apache.log4j.spi.ThrowableInformation;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TimeZone;
 
 public class JSONEventLayoutV1 extends Layout {
 
@@ -31,7 +32,9 @@ public class JSONEventLayoutV1 extends Layout {
     private static Integer version = 1;
 
     private JSONObject logstashEvent;
-    public static final FastDateFormat ISO_DATETIME_TIME_ZONE_FORMAT_WITH_MILLIS = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss.SSSZZ");
+
+    public static final TimeZone UTC = TimeZone.getTimeZone("UTC");
+    public static final FastDateFormat ISO_DATETIME_TIME_ZONE_FORMAT_WITH_MILLIS = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", UTC);
 
     public static String dateFormat(long timestamp) {
         return ISO_DATETIME_TIME_ZONE_FORMAT_WITH_MILLIS.format(new Date(timestamp));

--- a/src/test/java/net/logstash/log4j/JSONEventLayoutTest.java
+++ b/src/test/java/net/logstash/log4j/JSONEventLayoutTest.java
@@ -199,9 +199,8 @@ public class JSONEventLayoutTest {
     }
 
     @Test
-    @Ignore
     public void testDateFormat() {
         long timestamp = 1364844991207L;
-        Assert.assertEquals("format does not produce expected output", "2013-04-01T21:36:31.207+02:00", JSONEventLayout.dateFormat(timestamp));
+        Assert.assertEquals("format does not produce expected output", "2013-04-01T19:36:31.207Z", JSONEventLayout.dateFormat(timestamp));
     }
 }

--- a/src/test/java/net/logstash/log4j/JSONEventV1LayoutTest.java
+++ b/src/test/java/net/logstash/log4j/JSONEventV1LayoutTest.java
@@ -180,9 +180,8 @@ public class JSONEventV1LayoutTest {
     }
 
     @Test
-    @Ignore
     public void testDateFormat() {
         long timestamp = 1364844991207L;
-        Assert.assertEquals("format does not produce expected output", "2013-04-01T21:36:31.207+02:00", JSONEventLayoutV1.dateFormat(timestamp));
+        Assert.assertEquals("format does not produce expected output", "2013-04-01T19:36:31.207Z", JSONEventLayoutV1.dateFormat(timestamp));
     }
 }


### PR DESCRIPTION
Make sure `@timestamp` is in UTC rather than whatever random timezone the app server is set to.  Eliminates the need for logstash hacks[1] to rewrite `@timestamp` when the server is using a local timezone.

Avoids the common Logstash+ElasticSearch+Kibana problem where data is stored in an index other than the one Kibana expects and searches are missing N hours of data, where N is the local offset from UTC.

[1] For example:

```
filter {

  mutate {
    tags => ["local_ts"]
    rename => ["@timestamp", "_ts_local"]
  }

  date {
    tags => ["local_ts"]
    match => ["_ts_local", "ISO8601"]
    add_tag => ["fixed_local_ts"]
    remove_tag => ["local_ts"]
  }

  mutate {
    tags => ["fixed_local_ts"]
    remove => ["_ts_local"]
    remove_tag => ["fixed_local_ts"]
  }
}
```
