### PR TITLE
Added @type and @tags support

### DIFF
--- a/src/main/java/net/logstash/log4j/JSONEventLayout.java
+++ b/src/main/java/net/logstash/log4j/JSONEventLayout.java
@@ -19,6 +19,8 @@ public class JSONEventLayout extends Layout {
     private boolean locationInfo = false;
 
     private String tags = "";
+    private String logstashType = "default";
+    
     private boolean ignoreThrowable = false;
 
     private boolean activeIgnoreThrowable = ignoreThrowable;
@@ -70,11 +72,12 @@ public class JSONEventLayout extends Layout {
         logstashEvent.put("@source_host", hostname);
         logstashEvent.put("@message", loggingEvent.getRenderedMessage());
         logstashEvent.put("@timestamp", dateFormat(timestamp));        
+        logstashEvent.put("@type", logstashType);
         
         if (!tags.isEmpty()) {
         	logstashEvent.put("@tags", tags.split(","));
         }
-
+        
         if (loggingEvent.getThrowableInformation() != null) {
             final ThrowableInformation throwableInformation = loggingEvent.getThrowableInformation();
             if (throwableInformation.getThrowable().getClass().getCanonicalName() != null) {
@@ -136,6 +139,14 @@ public class JSONEventLayout extends Layout {
 
 	public void setTags(String tags) {
 		this.tags = tags;
+	}
+
+	public String getLogstashType() {
+		return logstashType;
+	}
+
+	public void setLogstashType(String logstashType) {
+		this.logstashType = logstashType;
 	}
 
 	public void activateOptions() {

--- a/src/main/java/net/logstash/log4j/JSONEventLayout.java
+++ b/src/main/java/net/logstash/log4j/JSONEventLayout.java
@@ -18,7 +18,7 @@ public class JSONEventLayout extends Layout {
 
     private boolean locationInfo = false;
 
-    private String tags;
+    private String tags = "";
     private boolean ignoreThrowable = false;
 
     private boolean activeIgnoreThrowable = ignoreThrowable;
@@ -69,7 +69,11 @@ public class JSONEventLayout extends Layout {
 
         logstashEvent.put("@source_host", hostname);
         logstashEvent.put("@message", loggingEvent.getRenderedMessage());
-        logstashEvent.put("@timestamp", dateFormat(timestamp));
+        logstashEvent.put("@timestamp", dateFormat(timestamp));        
+        
+        if (!tags.isEmpty()) {
+        	logstashEvent.put("@tags", tags.split(","));
+        }
 
         if (loggingEvent.getThrowableInformation() != null) {
             final ThrowableInformation throwableInformation = loggingEvent.getThrowableInformation();
@@ -126,7 +130,15 @@ public class JSONEventLayout extends Layout {
         this.locationInfo = locationInfo;
     }
 
-    public void activateOptions() {
+    public String getTags() {
+		return tags;
+	}
+
+	public void setTags(String tags) {
+		this.tags = tags;
+	}
+
+	public void activateOptions() {
         activeIgnoreThrowable = ignoreThrowable;
     }
 

--- a/src/main/java/net/logstash/log4j/JSONEventLayoutV1.java
+++ b/src/main/java/net/logstash/log4j/JSONEventLayoutV1.java
@@ -18,7 +18,7 @@ public class JSONEventLayoutV1 extends Layout {
 
     private boolean locationInfo = false;
 
-    private String tags;
+    private String tags = "";
     private boolean ignoreThrowable = false;
 
     private boolean activeIgnoreThrowable = ignoreThrowable;
@@ -79,6 +79,9 @@ public class JSONEventLayoutV1 extends Layout {
          */
         logstashEvent.put("source_host", hostname);
         logstashEvent.put("message", loggingEvent.getRenderedMessage());
+        if (!tags.isEmpty()) {
+            logstashEvent.put("tags", tags.split(","));
+        }
 
         if (loggingEvent.getThrowableInformation() != null) {
             final ThrowableInformation throwableInformation = loggingEvent.getThrowableInformation();
@@ -133,6 +136,14 @@ public class JSONEventLayoutV1 extends Layout {
     public void setLocationInfo(boolean locationInfo) {
         this.locationInfo = locationInfo;
     }
+
+    public String getTags() {
+		return tags;
+	}
+
+	public void setTags(String tags) {
+		this.tags = tags;
+	}
 
     public void activateOptions() {
         activeIgnoreThrowable = ignoreThrowable;

--- a/src/main/java/net/logstash/log4j/JSONEventLayoutV1.java
+++ b/src/main/java/net/logstash/log4j/JSONEventLayoutV1.java
@@ -19,6 +19,7 @@ public class JSONEventLayoutV1 extends Layout {
     private boolean locationInfo = false;
 
     private String tags = "";
+    private String logstashType = "default";
     private boolean ignoreThrowable = false;
 
     private boolean activeIgnoreThrowable = ignoreThrowable;
@@ -79,6 +80,7 @@ public class JSONEventLayoutV1 extends Layout {
          */
         logstashEvent.put("source_host", hostname);
         logstashEvent.put("message", loggingEvent.getRenderedMessage());
+        logstashEvent.put("type", logstashType);
         if (!tags.isEmpty()) {
             logstashEvent.put("tags", tags.split(","));
         }
@@ -145,7 +147,15 @@ public class JSONEventLayoutV1 extends Layout {
 		this.tags = tags;
 	}
 
-    public void activateOptions() {
+    public String getLogstashType() {
+		return logstashType;
+	}
+
+	public void setLogstashType(String logstashType) {
+		this.logstashType = logstashType;
+	}
+
+	public void activateOptions() {
         activeIgnoreThrowable = ignoreThrowable;
     }
 

--- a/src/main/java/net/logstash/log4j/JSONEventLayoutV1.java
+++ b/src/main/java/net/logstash/log4j/JSONEventLayoutV1.java
@@ -78,7 +78,7 @@ public class JSONEventLayoutV1 extends Layout {
         /**
          * Now we start injecting our own stuff.
          */
-        logstashEvent.put("source_host", hostname);
+        logstashEvent.put("host", hostname);
         logstashEvent.put("message", loggingEvent.getRenderedMessage());
         logstashEvent.put("type", logstashType);
         if (!tags.isEmpty()) {

--- a/src/test/java/net/logstash/log4j/JSONEventV1LayoutTest.java
+++ b/src/test/java/net/logstash/log4j/JSONEventV1LayoutTest.java
@@ -25,7 +25,7 @@ public class JSONEventV1LayoutTest {
     static MockAppenderV1 appender;
     static final String[] logstashFields = new String[]{
             "message",
-            "source_host",
+            "host",
             "@timestamp",
             "@version"
     };


### PR DESCRIPTION
now layout contains _@type_ or _type_  (depends on layout version), using property logstashType.

I tried to integrate it with elasticsearch and it is no possible to specify _type_ property because it is already reserved.
Here is my test config

```
  rabbitmq: 
    type: com.plant42.log4j.appenders.RabbitMQAppender
    identifier: test_elasticsearch
    host: localhost
    port: 5672
    username: guest
    password: guest
    virtualHost: /
    exchange: logstash
    #type: direct  # unable to use type
    durable: true
    queue: logstash-queue
    layout:
      type: net.logstash.log4j.JSONEventLayoutV1
      tags: "es_test,rabbitmq"
      locationInfo: true
      logstashType: "elasticsearch_test"
```

Hope logstashType is good name. 
Tag - comma-separated list without space after comma.
Looks like in new version logstash no option _source__host_ but _host_ exists. So I changed it.
