### PR TITLE
Preventing NPE after (de)serialization of a LoggingEvent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *.iml
 target/*
 .idea
+.settings/*
+.project
+.classpath

--- a/src/main/java/net/logstash/log4j/JSONEventLayoutV1.java
+++ b/src/main/java/net/logstash/log4j/JSONEventLayoutV1.java
@@ -107,11 +107,13 @@ public class JSONEventLayoutV1 extends Layout {
 
         if (loggingEvent.getThrowableInformation() != null) {
             final ThrowableInformation throwableInformation = loggingEvent.getThrowableInformation();
-            if (throwableInformation.getThrowable().getClass().getCanonicalName() != null) {
-                exceptionInformation.put("exception_class", throwableInformation.getThrowable().getClass().getCanonicalName());
-            }
-            if (throwableInformation.getThrowable().getMessage() != null) {
-                exceptionInformation.put("exception_message", throwableInformation.getThrowable().getMessage());
+            if (throwableInformation.getThrowable() != null) {
+                if (throwableInformation.getThrowable().getClass().getCanonicalName() != null) {
+                    exceptionInformation.put("exception_class", throwableInformation.getThrowable().getClass().getCanonicalName());
+                }
+                if (throwableInformation.getThrowable().getMessage() != null) {
+                    exceptionInformation.put("exception_message", throwableInformation.getThrowable().getMessage());
+                }
             }
             if (throwableInformation.getThrowableStrRep() != null) {
                 String stackTrace = StringUtils.join(throwableInformation.getThrowableStrRep(), "\n");


### PR DESCRIPTION
When making use of a SocketAppender logging events are serialized and de-serialized. Because the throwable field on ThrowableInformation is transient it will not be available for further processing after de-serialization. Causing a NullPointerException.

My change checks if the throwable field is not null before trying to use it.
