### PR TITLE
Separate logstash event creation from formatting operation

### DIFF
--- a/FORK.md
+++ b/FORK.md
@@ -1,0 +1,3 @@
+Simple refactoring of the JSONEventLayoutV1 format method to separate the creation of the Logstash event and the formatting operation.
+The benefit is subclasses of JSONEventLayoutV1 can create the Logstash event, add any specific details to the event, and
+then get the formatted string.

--- a/FORK.md
+++ b/FORK.md
@@ -1,3 +1,5 @@
 Simple refactoring of the JSONEventLayoutV1 format method to separate the creation of the Logstash event and the formatting operation.
 The benefit is subclasses of JSONEventLayoutV1 can create the Logstash event, add any specific details to the event, and
 then get the formatted string.
+
+Also, added the ability to customize the output field names.

--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,8 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>2.3.2</version>
           <configuration>
-            <source>1.5</source>
-            <target>1.5</target>
+            <source>1.7</source>
+            <target>1.7</target>
           </configuration>
         </plugin>
         <plugin>

--- a/src/main/java/net/logstash/log4j/IJSONEventLayout.java
+++ b/src/main/java/net/logstash/log4j/IJSONEventLayout.java
@@ -1,0 +1,10 @@
+package net.logstash.log4j;
+
+
+public interface IJSONEventLayout {
+
+    public abstract String getUserFields();
+    public abstract void  setUserFields(String userFields);
+    public abstract boolean getLocationInfo();
+    public abstract void setLocationInfo(boolean locationInfo);
+}

--- a/src/main/java/net/logstash/log4j/JSONEventLayoutV1.java
+++ b/src/main/java/net/logstash/log4j/JSONEventLayoutV1.java
@@ -60,6 +60,12 @@ public class JSONEventLayoutV1 extends Layout {
     }
 
     public String format(LoggingEvent loggingEvent) {
+        JSONObject lsEvent = createLogstashEvent(loggingEvent);
+
+        return lsEvent.toString() + "\n";
+    }
+
+    protected JSONObject createLogstashEvent(LoggingEvent loggingEvent) {
         threadName = loggingEvent.getThreadName();
         timestamp = loggingEvent.getTimeStamp();
         exceptionInformation = new HashMap<String, Object>();
@@ -82,7 +88,7 @@ public class JSONEventLayoutV1 extends Layout {
          */
         if (getUserFields() != null) {
             String userFlds = getUserFields();
-            LogLog.debug("["+whoami+"] Got user data from log4j property: "+ userFlds);
+            LogLog.debug("[" + whoami + "] Got user data from log4j property: " + userFlds);
             addUserFields(userFlds);
         }
 
@@ -134,7 +140,7 @@ public class JSONEventLayoutV1 extends Layout {
         addEventData("level", loggingEvent.getLevel().toString());
         addEventData("thread_name", threadName);
 
-        return logstashEvent.toString() + "\n";
+        return logstashEvent;
     }
 
     public boolean ignoresThrowable() {

--- a/src/main/java/net/logstash/log4j/JSONEventLayoutV1.java
+++ b/src/main/java/net/logstash/log4j/JSONEventLayoutV1.java
@@ -14,7 +14,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.TimeZone;
 
-public class JSONEventLayoutV1 extends Layout {
+public class JSONEventLayoutV1 extends Layout implements IJSONEventLayout {
 
     private boolean locationInfo = false;
     private String customUserFields;
@@ -152,6 +152,7 @@ public class JSONEventLayoutV1 extends Layout {
      *
      * @return true if location information is included in log messages, false otherwise.
      */
+    @Override
     public boolean getLocationInfo() {
         return locationInfo;
     }
@@ -161,11 +162,15 @@ public class JSONEventLayoutV1 extends Layout {
      *
      * @param locationInfo true if location information should be included, false otherwise.
      */
+    @Override
     public void setLocationInfo(boolean locationInfo) {
         this.locationInfo = locationInfo;
     }
 
+    @Override
     public String getUserFields() { return customUserFields; }
+
+    @Override
     public void setUserFields(String userFields) { this.customUserFields = userFields; }
 
     public void activateOptions() {
@@ -185,6 +190,7 @@ public class JSONEventLayoutV1 extends Layout {
             }
         }
     }
+
     private void addEventData(String keyname, Object keyval) {
         if (null != keyval) {
             logstashEvent.put(keyname, keyval);

--- a/src/main/java/net/logstash/log4j/JSONEventLayoutV2.java
+++ b/src/main/java/net/logstash/log4j/JSONEventLayoutV2.java
@@ -19,13 +19,13 @@ import java.util.TimeZone;
 
 /**
  * Log4j JSON Layout providing mutable output field names
- *
+ * <p/>
  * Based upon the similar field name solution for logback found here
  * https://github.com/logstash/logstash-logback-encoder
- *
+ * <p/>
  * Also allows for "flattening" of the output structure, removing any nested structures
  */
-public class JSONEventLayoutV2 extends Layout {
+public class JSONEventLayoutV2 extends Layout implements IJSONEventLayout {
 
     protected ErrorHandler errorHandler = new OnlyOnceErrorHandler();
 
@@ -42,6 +42,10 @@ public class JSONEventLayoutV2 extends Layout {
 
     public static String dateFormat(long timestamp) {
         return ISO_DATETIME_TIME_ZONE_FORMAT_WITH_MILLIS.format(timestamp);
+    }
+
+    public JSONEventLayoutV2() {
+        this(true);
     }
 
     public JSONEventLayoutV2(boolean isLocationInfo) {
@@ -225,6 +229,7 @@ public class JSONEventLayoutV2 extends Layout {
         fieldNames.setFlattenOutput(isFlatten);
     }
 
+    @Override
     public boolean ignoresThrowable() {
         return ignoreThrowable;
     }
@@ -234,6 +239,7 @@ public class JSONEventLayoutV2 extends Layout {
      *
      * @return true if location information is included in log messages, false otherwise.
      */
+    @Override
     public boolean getLocationInfo() {
         return locationInfo;
     }
@@ -243,14 +249,17 @@ public class JSONEventLayoutV2 extends Layout {
      *
      * @param locationInfo true if location information should be included, false otherwise.
      */
+    @Override
     public void setLocationInfo(boolean locationInfo) {
         this.locationInfo = locationInfo;
     }
 
+    @Override
     public String getUserFields() {
         return customUserFields;
     }
 
+    @Override
     public void setUserFields(String userFields) {
         this.customUserFields = userFields;
     }

--- a/src/main/java/net/logstash/log4j/JSONEventLayoutV2.java
+++ b/src/main/java/net/logstash/log4j/JSONEventLayoutV2.java
@@ -1,0 +1,262 @@
+package net.logstash.log4j;
+
+
+import net.logstash.log4j.data.HostData;
+import net.logstash.log4j.fieldnames.LogstashFieldNames;
+import net.minidev.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.time.FastDateFormat;
+import org.apache.log4j.Layout;
+import org.apache.log4j.helpers.LogLog;
+import org.apache.log4j.helpers.OnlyOnceErrorHandler;
+import org.apache.log4j.spi.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TimeZone;
+
+
+/**
+ * Log4j JSON Layout providing mutable output field names
+ *
+ * Based upon the similar field name solution for logback found here
+ * https://github.com/logstash/logstash-logback-encoder
+ *
+ * Also allows for "flattening" of the output structure, removing any nested structures
+ */
+public class JSONEventLayoutV2 extends Layout {
+
+    protected ErrorHandler errorHandler = new OnlyOnceErrorHandler();
+
+    private LogstashFieldNames fieldNames = new LogstashFieldNames();
+    private boolean locationInfo = true;
+    private String customUserFields;
+    private boolean ignoreThrowable = false;
+    private String hostname = new HostData().getHostName();
+    private static Integer version = 1;
+
+    public static final TimeZone UTC = TimeZone.getTimeZone("UTC");
+    public static final FastDateFormat ISO_DATETIME_TIME_ZONE_FORMAT_WITH_MILLIS = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", UTC);
+    public static final String ADDITIONAL_DATA_PROPERTY = "net.logstash.log4j.JSONEventLayoutV2.UserFields";
+
+    public static String dateFormat(long timestamp) {
+        return ISO_DATETIME_TIME_ZONE_FORMAT_WITH_MILLIS.format(timestamp);
+    }
+
+    public JSONEventLayoutV2(boolean isLocationInfo) {
+        locationInfo = isLocationInfo;
+    }
+
+    public String format(LoggingEvent loggingEvent) {
+        JSONObject lsEvent = createLogstashEvent(loggingEvent);
+
+        return lsEvent.toString() + "\n";
+    }
+
+    protected JSONObject createLogstashEvent(LoggingEvent loggingEvent) {
+        String threadName = loggingEvent.getThreadName();
+        Long timestamp = loggingEvent.getTimeStamp();
+
+        Map mdc = loggingEvent.getProperties();
+        String ndc = loggingEvent.getNDC();
+
+        JSONObject logstashEvent = new JSONObject();
+        String whoami = this.getClass().getSimpleName();
+
+        /**
+         * All v1 of the event format requires is
+         * "@timestamp" and "@version"
+         * Every other field is arbitrary
+         */
+        addEventData(logstashEvent, fieldNames.getVersion(), version);
+        addEventData(logstashEvent, fieldNames.getTimestamp(), dateFormat(timestamp));
+
+        /**
+         * Extract and add fields from log4j config, if defined
+         */
+        if (getUserFields() != null) {
+            String userFlds = getUserFields();
+            LogLog.debug("[" + whoami + "] Got user data from log4j property: " + userFlds);
+            addUserFields(logstashEvent, userFlds);
+        }
+
+        /**
+         * Extract fields from system properties, if defined
+         * Note that CLI props will override conflicts with log4j config
+         */
+        if (System.getProperty(ADDITIONAL_DATA_PROPERTY) != null) {
+            if (getUserFields() != null) {
+                LogLog.warn("[" + whoami + "] Loading UserFields from command-line. This will override any UserFields set in the log4j configuration file");
+            }
+            String userFieldsProperty = System.getProperty(ADDITIONAL_DATA_PROPERTY);
+            LogLog.debug("[" + whoami + "] Got user data from system property: " + userFieldsProperty);
+            addUserFields(logstashEvent, userFieldsProperty);
+        }
+
+        /**
+         * Now we start injecting our own stuff.
+         */
+        addEventData(logstashEvent, fieldNames.getHostName(), hostname);
+        addEventData(logstashEvent, fieldNames.getMessage(), loggingEvent.getRenderedMessage());
+
+        if (loggingEvent.getThrowableInformation() != null) {
+            final ThrowableInformation throwableInformation = loggingEvent.getThrowableInformation();
+
+            HashMap<String, Object> exceptionInformation = new HashMap<String, Object>();
+            if (throwableInformation.getThrowable().getClass().getCanonicalName() != null) {
+                exceptionInformation.put(fieldNames.getExceptionClass(), throwableInformation.getThrowable().getClass().getCanonicalName());
+            }
+            if (throwableInformation.getThrowable().getMessage() != null) {
+                exceptionInformation.put(fieldNames.getExceptionMessage(), throwableInformation.getThrowable().getMessage());
+            }
+            if (throwableInformation.getThrowableStrRep() != null) {
+                String stackTrace = StringUtils.join(throwableInformation.getThrowableStrRep(), "\n");
+                exceptionInformation.put(fieldNames.getStackTrace(), stackTrace);
+            }
+            if (fieldNames.getException() != null) {
+                addEventData(logstashEvent, fieldNames.getException(), exceptionInformation);
+            } else {
+                addEventData(logstashEvent, exceptionInformation);
+            }
+
+        }
+
+        if (getLocationInfo()) {
+            LocationInfo info = loggingEvent.getLocationInformation();
+            Map<String, String> locMap = new HashMap<String, String>();
+
+            addEventData(locMap, fieldNames.getCallerFile(), info.getFileName());
+            addEventData(locMap, fieldNames.getCallerLine(), info.getLineNumber());
+            addEventData(locMap, fieldNames.getCallerClass(), info.getClassName());
+            addEventData(locMap, fieldNames.getCallerMethod(), info.getMethodName());
+
+            if (fieldNames.getCaller() != null) {
+                addEventData(logstashEvent, fieldNames.getCaller(), locMap);
+            } else {
+                addEventData(logstashEvent, locMap);
+            }
+
+           /* addEventData(logstashEvent, fieldNames.getCallerFile(), info.getFileName());
+            addEventData(logstashEvent, fieldNames.getCallerLine(), info.getLineNumber());
+            addEventData(logstashEvent, fieldNames.getCallerClass(), info.getClassName());
+            addEventData(logstashEvent, fieldNames.getCallerMethod(), info.getMethodName());*/
+        }
+
+        addEventData(logstashEvent, fieldNames.getLogger(), loggingEvent.getLoggerName());
+
+
+        if (fieldNames.getMdc() != null) {
+            addEventData(logstashEvent, fieldNames.getMdc(), mdc);
+
+        } else {
+            addEventData(logstashEvent, mdc);
+        }
+
+
+        addEventData(logstashEvent, fieldNames.getNdc(), ndc);
+        addEventData(logstashEvent, fieldNames.getLevel(), loggingEvent.getLevel().toString());
+        addEventData(logstashEvent, fieldNames.getThread(), threadName);
+
+        return logstashEvent;
+    }
+
+    private void addEventData(JSONObject logstashEvent, Map map) {
+        Set<Map.Entry> entries = map.entrySet();
+        for (Map.Entry entry : entries) {
+            String key = entry.getKey().toString();
+            Object value = entry.getValue();
+            addEventData(logstashEvent, key, value);
+        }
+    }
+
+    private void addEventData(JSONObject logstashEvent, String keyName, Object keyVal) {
+        if (keyVal != null && keyName != null) {
+            logstashEvent.put(keyName, keyVal);
+        }
+    }
+
+    private void addEventData(Map map, String keyName, Object keyVal) {
+        if (keyVal != null && keyName != null) {
+            map.put(keyName, keyVal);
+        }
+    }
+
+    //TODO: This should be just using a JSON string instead of comma separated "name:value" pairs
+    private void addUserFields(JSONObject logstashEvent, String data) {
+        if (data != null) {
+            String[] pairs = data.split(",");
+            for (String pair : pairs) {
+                String[] userField = pair.split(":", 2);
+                if (userField[0] != null) {
+                    String key = userField[0];
+                    String val = userField[1];
+                    addEventData(logstashEvent, key, val);
+                }
+            }
+        }
+    }
+
+
+    public LogstashFieldNames getFieldNames() {
+        return fieldNames;
+    }
+
+    public void setFieldNames(LogstashFieldNames fieldNames) {
+        this.fieldNames = fieldNames;
+    }
+
+    public void setFieldsClassName(String fieldsClassName) {
+        try {
+            Class clazz = Class.forName(fieldsClassName);
+            Object o = clazz.newInstance();
+            if (o instanceof LogstashFieldNames) {
+                setFieldNames((LogstashFieldNames) o);
+            } else {
+                errorHandler.error("Class for " + fieldsClassName + " is not a valid type for defining field names.  Will use default field names");
+            }
+
+        } catch (Exception e) {
+            errorHandler.error("Failed to load class for FieldNames " + fieldsClassName, e, ErrorCode.GENERIC_FAILURE);
+        }
+    }
+
+    public void setFlattenOutput(boolean isFlatten) {
+        fieldNames.setFlattenOutput(isFlatten);
+    }
+
+    public boolean ignoresThrowable() {
+        return ignoreThrowable;
+    }
+
+    /**
+     * Query whether log messages include location information.
+     *
+     * @return true if location information is included in log messages, false otherwise.
+     */
+    public boolean getLocationInfo() {
+        return locationInfo;
+    }
+
+    /**
+     * Set whether log messages should include location information.
+     *
+     * @param locationInfo true if location information should be included, false otherwise.
+     */
+    public void setLocationInfo(boolean locationInfo) {
+        this.locationInfo = locationInfo;
+    }
+
+    public String getUserFields() {
+        return customUserFields;
+    }
+
+    public void setUserFields(String userFields) {
+        this.customUserFields = userFields;
+    }
+
+    public void activateOptions() {
+
+        //activeIgnoreThrowable = ignoreThrowable;
+    }
+}

--- a/src/main/java/net/logstash/log4j/fieldnames/LogstashCommonFieldNames.java
+++ b/src/main/java/net/logstash/log4j/fieldnames/LogstashCommonFieldNames.java
@@ -13,6 +13,9 @@
  */
 package net.logstash.log4j.fieldnames;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Common field names
  */
@@ -43,5 +46,15 @@ public abstract class LogstashCommonFieldNames {
 
     public void setMessage(String message) {
         this.message = message;
+    }
+
+    public List<String> listCommonNames() {
+        List<String> namesList = new ArrayList<>();
+
+        namesList.add(getTimestamp());
+        namesList.add(getMessage());
+        namesList.add(getVersion());
+
+        return  namesList;
     }
 }

--- a/src/main/java/net/logstash/log4j/fieldnames/LogstashCommonFieldNames.java
+++ b/src/main/java/net/logstash/log4j/fieldnames/LogstashCommonFieldNames.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.logstash.log4j.fieldnames;
+
+/**
+ * Common field names
+ */
+public abstract class LogstashCommonFieldNames {
+    private String timestamp = "@timestamp";
+    private String version = "@version";
+    private String message = "message";
+
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/net/logstash/log4j/fieldnames/LogstashFieldNames.java
+++ b/src/main/java/net/logstash/log4j/fieldnames/LogstashFieldNames.java
@@ -1,0 +1,243 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.logstash.log4j.fieldnames;
+
+/**
+ * Names of standard fields that appear in the JSON output.
+ *
+ * Based upn the similar solution for logback
+ * https://github.com/logstash/logstash-logback-encoder/blob/master/src/main/java/net/logstash/logback/fieldnames/LogstashFieldNames.java
+ */
+public class LogstashFieldNames extends LogstashCommonFieldNames {
+
+    private String logger = "loggername";
+    private String thread = "threadname";
+    private String level = "level";
+    private String levelValue = "levelvalue";
+
+    private String callerClass = "classname";
+    private String callerMethod = "methodname";
+    private String callerFile = "filename";
+    private String callerLine = "linenumber";
+    private String stackTrace = "stacktrace";
+    private String tags = "tags";
+    private String ndc = "ndc";
+
+    private String hostName = "hostname";
+    private String exceptionClass = "exceptionclass";
+    private String exceptionMessage = "exceptionmessage";
+
+    //IF we populate these, the output will create nested data for these names
+    private String exception;
+    private String caller;
+    private String mdc;
+    private String context;
+
+    public static final String EXCEPTION_DEFAULT = "exception";
+    public static final String CALLER_DEFAULT = "caller";
+    public static final String MDC_DEFAULT = "mdc";
+    public static final String CONTEXT_DEFAULT = "context";
+
+
+    public void setFlattenOutput(Boolean isFlatten) {
+        if (isFlatten) {
+            setException(null);
+            setCaller(null);
+            setMdc(null);
+            setContext(null);
+        } else {
+            String exception = getException() != null ? getException() : EXCEPTION_DEFAULT;
+            String caller = getCaller() != null ? getCaller() : CALLER_DEFAULT;
+            String mdc = getMdc() != null ? getMdc() : MDC_DEFAULT;
+            String context = getContext() != null ? getContext() : CONTEXT_DEFAULT;
+            setException(exception);
+            setCaller(caller);
+            setMdc(mdc);
+            setContext(context);
+        }
+    }
+
+    public String getLogger() {
+        return logger;
+    }
+
+    public void setLogger(String logger) {
+        this.logger = logger;
+    }
+
+    public String getThread() {
+        return thread;
+    }
+
+    public void setThread(String thread) {
+        this.thread = thread;
+    }
+
+    public String getLevel() {
+        return level;
+    }
+
+    public void setLevel(String level) {
+        this.level = level;
+    }
+
+    public String getLevelValue() {
+        return levelValue;
+    }
+
+    public void setLevelValue(String levelValue) {
+        this.levelValue = levelValue;
+    }
+
+    /**
+     * The name of the caller object field.
+     * <p/>
+     * If this returns null, then the caller data fields will be written inline at the root level of the JSON event output (e.g. as a sibling to all the other fields in this class).
+     * <p/>
+     * If this returns non-null, then the caller data fields will be written inside an object with field name returned by this method
+     */
+    public String getCaller() {
+        return caller;
+    }
+
+    public void setCaller(String caller) {
+        this.caller = caller;
+    }
+
+    public String getCallerClass() {
+        return callerClass;
+    }
+
+    public void setCallerClass(String callerClass) {
+        this.callerClass = callerClass;
+    }
+
+    public String getCallerMethod() {
+        return callerMethod;
+    }
+
+    public void setCallerMethod(String callerMethod) {
+        this.callerMethod = callerMethod;
+    }
+
+    public String getCallerFile() {
+        return callerFile;
+    }
+
+    public void setCallerFile(String callerFile) {
+        this.callerFile = callerFile;
+    }
+
+    public String getCallerLine() {
+        return callerLine;
+    }
+
+    public void setCallerLine(String callerLine) {
+        this.callerLine = callerLine;
+    }
+
+    public String getStackTrace() {
+        return stackTrace;
+    }
+
+    public void setStackTrace(String stackTrace) {
+        this.stackTrace = stackTrace;
+    }
+
+    public String getTags() {
+        return tags;
+    }
+
+    public void setTags(String tags) {
+        this.tags = tags;
+    }
+
+    /**
+     * The name of the mdc object field.
+     * <p/>
+     * If this returns null, then the mdc fields will be written inline at the root level of the JSON event output (e.g. as a sibling to all the other fields in this class).
+     * <p/>
+     * If this returns non-null, then the mdc fields will be written inside an object with field name returned by this method
+     */
+    public String getMdc() {
+        return mdc;
+    }
+
+    public void setMdc(String mdc) {
+        this.mdc = mdc;
+    }
+
+    /**
+     * The name of the context object field.
+     * <p/>
+     * If this returns null, then the context fields will be written inline at the root level of the JSON event output (e.g. as a sibling to all the other fields in this class).
+     * <p/>
+     * If this returns non-null, then the context fields will be written inside an object with field name returned by this method
+     */
+    public String getContext() {
+        return context;
+    }
+
+    public void setContext(String context) {
+        this.context = context;
+    }
+
+    public String getHostName() {
+        return hostName;
+    }
+
+    public void setHostName(String hostName) {
+        this.hostName = hostName;
+    }
+
+    public String getExceptionClass() {
+        return exceptionClass;
+    }
+
+    public void setExceptionClass(String exceptionClass) {
+        this.exceptionClass = exceptionClass;
+    }
+
+    public String getExceptionMessage() {
+        return exceptionMessage;
+    }
+
+    public void setExceptionMessage(String exceptionMessage) {
+        this.exceptionMessage = exceptionMessage;
+    }
+
+    /**
+     * The name of the exception object field.
+     * <p/>
+     * If this returns null, then the context fields will be written inline at the root level of the JSON event output (e.g. as a sibling to all the other fields in this class).
+     * <p/>
+     * If this returns non-null, then the context fields will be written inside an object with field name returned by this method
+     */
+    public String getException() {
+        return exception;
+    }
+
+    public void setException(String exception) {
+        this.exception = exception;
+    }
+
+
+    public String getNdc() {
+        return ndc;
+    }
+
+    public void setNdc(String ndc) {
+        this.ndc = ndc;
+    }
+}

--- a/src/main/java/net/logstash/log4j/fieldnames/LogstashFieldNames.java
+++ b/src/main/java/net/logstash/log4j/fieldnames/LogstashFieldNames.java
@@ -13,6 +13,9 @@
  */
 package net.logstash.log4j.fieldnames;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Names of standard fields that appear in the JSON output.
  *
@@ -24,7 +27,7 @@ public class LogstashFieldNames extends LogstashCommonFieldNames {
     private String logger = "loggername";
     private String thread = "threadname";
     private String level = "level";
-    private String levelValue = "levelvalue";
+    //private String levelValue = "levelvalue";
 
     private String callerClass = "classname";
     private String callerMethod = "methodname";
@@ -92,6 +95,7 @@ public class LogstashFieldNames extends LogstashCommonFieldNames {
         this.level = level;
     }
 
+   /**
     public String getLevelValue() {
         return levelValue;
     }
@@ -99,7 +103,7 @@ public class LogstashFieldNames extends LogstashCommonFieldNames {
     public void setLevelValue(String levelValue) {
         this.levelValue = levelValue;
     }
-
+    **/
     /**
      * The name of the caller object field.
      * <p/>
@@ -239,5 +243,24 @@ public class LogstashFieldNames extends LogstashCommonFieldNames {
 
     public void setNdc(String ndc) {
         this.ndc = ndc;
+    }
+
+
+    public List<String> listNames() {
+        List<String> namesList = new ArrayList<>();
+
+        namesList.addAll(super.listCommonNames());
+        namesList.add(getLogger());
+        namesList.add(getThread());
+        namesList.add(getLevel());
+        namesList.add(getCallerClass());
+        namesList.add(getCallerMethod());
+        namesList.add(getCallerFile());
+        namesList.add(getCallerLine());
+        namesList.add(getStackTrace());
+        namesList.add(getTags());
+        namesList.add(getNdc());
+
+        return  namesList;
     }
 }

--- a/src/test/java/net/logstash/log4j/MockAppenderV1.java
+++ b/src/test/java/net/logstash/log4j/MockAppenderV1.java
@@ -9,7 +9,7 @@ import org.apache.log4j.Layout;
 
 public class MockAppenderV1 extends AppenderSkeleton {
 
-    private static List messages = new ArrayList();
+    private List messages = new ArrayList();
 
     public MockAppenderV1(Layout layout){
         this.layout = layout;
@@ -27,7 +27,7 @@ public class MockAppenderV1 extends AppenderSkeleton {
         return true;
     }
 
-    public static String[] getMessages() {
+    public String[] getMessages() {
         return (String[]) messages.toArray(new String[messages.size()]);
     }
 


### PR DESCRIPTION
I've performed a very simple refactoring to expose the logstash json event to subclasses of JSONEventLayoutV1.  The intent is to allow subclasses to override the format method and still be able to use the default logstash event creation logic.

So, something like the following:

``` java
    @Override
    public String format(LoggingEvent loggingEvent) {
       JSONObject logstashJson = createLogstashEvent(loggingEvent);
        String[] tags = new String[] {"CustomHardcodedTag"};
        logstashJson.put("tags", tags);

        return logstashJson.toString() + "\n";    
    }
```
