### PR TITLE
converting the packaging to bundle, #22, fixes osgi bundle loading in…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>net.logstash.log4j</groupId>
   <artifactId>jsonevent-layout</artifactId>
-  <packaging>jar</packaging>
+  <packaging>bundle</packaging>
   <version>1.8-SNAPSHOT</version>
   <name>jsonevent-layout</name>
   <description>Log4j pattern layout that conforms to the logstash json_event format</description>
@@ -96,6 +96,24 @@
       </plugin>
     </plugins>
   </pluginManagement>
+  <plugins>
+  <plugin>
+     <groupId>org.apache.felix</groupId>
+     <artifactId>maven-bundle-plugin</artifactId>
+     <version>2.3.7</version>
+     <extensions>true</extensions>
+     <configuration>
+         <instructions>
+             <Bundle-Name>${project.groupId}.${project.artifactId}</Bundle-Name>
+             <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
+             <Import-Package>!*</Import-Package>
+             <Fragment-Host>org.ops4j.pax.logging.pax-logging-service;bundle-version="[1.6,1.9)"</Fragment-Host>
+             <Embed-Dependency>*;scope=compile|runtime;inline=true</Embed-Dependency>
+             <Implementation-Version>${project.version}</Implementation-Version>
+         </instructions>
+     </configuration>
+ </plugin>
+  </plugins>
   </build>
   <dependencies>
     <dependency>
@@ -122,29 +140,6 @@
     </dependency>
   </dependencies>
   <profiles>
-      <profile>
-          <id>bundle</id>
-          <build>
-              <plugins>
-                  <plugin>
-                      <groupId>org.apache.felix</groupId>
-                      <artifactId>maven-bundle-plugin</artifactId>
-                      <version>2.3.7</version>
-                      <extensions>true</extensions>
-                      <configuration>
-                          <instructions>
-                              <Bundle-Name>${project.groupId}.${project.artifactId}</Bundle-Name>
-                              <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
-                              <Import-Package>!*</Import-Package>
-                              <Fragment-Host>org.ops4j.pax.logging.pax-logging-service;bundle-version="[1.6,1.7)"</Fragment-Host>
-                              <Embed-Dependency>*;scope=compile|runtime;inline=true</Embed-Dependency>
-                              <Implementation-Version>${project.version}</Implementation-Version>
-                          </instructions>
-                      </configuration>
-                  </plugin>
-              </plugins>
-          </build>
-      </profile>
     <profile>
       <id>release-sign-artifacts</id>
       <activation>


### PR DESCRIPTION
1) Tested with fuse loading, the fragment loads and the logs are generated. 
-- below are the changes
- converted packaging to bundle. 
- default jar is packaged with all the dependecies
