### PR TITLE
Replace dots with underscores in MDC

### DIFF
--- a/src/main/java/net/logstash/log4j/JSONEventLayoutV1.java
+++ b/src/main/java/net/logstash/log4j/JSONEventLayoutV1.java
@@ -63,7 +63,12 @@ public class JSONEventLayoutV1 extends Layout {
         threadName = loggingEvent.getThreadName();
         timestamp = loggingEvent.getTimeStamp();
         exceptionInformation = new HashMap<String, Object>();
-        mdc = loggingEvent.getProperties();
+        mdc = new HashMap();
+        for (Object mdcObj : loggingEvent.getProperties().entrySet()) {
+            Map.Entry mapEntry = (Map.Entry) mdcObj;
+            String key = (String) mapEntry.getKey();
+            mdc.put(key.replaceAll("\\.", "_"), mapEntry.getValue());
+        }
         ndc = loggingEvent.getNDC();
 
         logstashEvent = new JSONObject();

--- a/src/test/java/net/logstash/log4j/JSONEventLayoutV1Test.java
+++ b/src/test/java/net/logstash/log4j/JSONEventLayoutV1Test.java
@@ -185,6 +185,19 @@ public class JSONEventLayoutV1Test {
     }
 
     @Test
+    public void testJSONEventLayoutEscapesMDCKeys() {
+        MDC.put("foo.bar","baz");
+        logger.warn("I should escape MDC field names in my log");
+        String message = appender.getMessages()[0];
+        Object obj = JSONValue.parse(message);
+        JSONObject jsonObject = (JSONObject) obj;
+        JSONObject mdc = (JSONObject) jsonObject.get("mdc");
+
+        Assert.assertFalse("Event contains not escaped key", mdc.containsKey("foo.bar"));
+        Assert.assertTrue("Event does not contain escaped key", mdc.containsKey("foo_bar"));
+    }
+
+    @Test
     public void testJSONEventLayoutExceptions() {
         String exceptionMessage = new String("shits on fire, yo");
         logger.fatal("uh-oh", new IllegalArgumentException(exceptionMessage));


### PR DESCRIPTION
ES 2.x doesn't support dots (`.`) in keys. This patch replaces `.` symbol with `_` in MDC keys.

Apache Camel uses `camel.breadcrumbId` and similar MDC keys.